### PR TITLE
fix: ensure fallback for missing tag_bar config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ wezterm.plugin
 
 Controls visual elements and separators.
 
+### Theme
+
+The plugin will try to use wezterm.config.colors.tab_bar if it's defined, if
+if it's not, will try config.ui.theme defined the plugin, in case none of both
+are defined, will use a fallback theme.
+
+> [!NOTE]
+> The plugin will first try to use wezterm.config.colors.tab_bar if it is defined.
+> If not, it will check config.ui.theme from the plugin's configuration. If neither
+> is set, it will fall back to a default theme.
+
+```lua
+ui.theme = {
+  bg_color = '#88C0D0',
+  fg_color = '#2E3440',
+  intensity = 'Normal',
+  underline = 'None',
+  italic = false,
+  strikethrough = false,
+}
+```
+
 ### Separators
 
 ```lua

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -134,6 +134,30 @@ local M = {}
 ---@param opts? WeztermStatusConfig Optional configuration overrides
 function M.apply_to_config(wezterm_config, opts)
   config = Utils.table_merge(config, opts or {})
+
+  local user_active_tab = wezterm_config.colors
+    and wezterm_config.colors.tab_bar
+    and wezterm_config.colors.tab_bar.active_tab
+
+  config.ui.theme = user_active_tab
+    or config.ui.theme
+    or {
+      bg_color = '#88C0D0',
+      fg_color = '#2E3440',
+      intensity = 'Normal',
+      underline = 'None',
+      italic = false,
+      strikethrough = false,
+    }
+
+  if not user_active_tab then
+    wezterm.log_warn(
+      "Wezterm-Status: No 'config.colors.tab_bar.active_tab' detected. "
+        .. "Falling back to the plugin's internal theme. "
+        .. "You can customize it via plugin configuration 'config.ui.theme'."
+        .. 'more info: https://github.com/yriveiro/wezterm-status/tree/main?tab=readme-ov-file#setup'
+    )
+  end
 end
 
 -- Register status bar update handler
@@ -141,10 +165,10 @@ wezterm.on('update-status', function(window, pane)
   local cells = Cells:new()
   local config_cells = config.cells
   local separators = config.ui.separators
-  local palette = window:effective_config().resolved_palette.tab_bar.active_tab
-  local bg = palette.bg_color
-  local fg = palette.fg_color
   local thin_right = separators.arrow_thin_right
+
+  local bg = config.ui.theme.bg_color
+  local fg = config.ui.theme.fg_color
 
   cells:push(fg, bg, separators.arrow_solid_right)
 

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -1,5 +1,6 @@
 ---@class WeztermUiConfig
 ---@field separators SeparatorConfig Visual separators used in the status bar
+---@field theme? TabBarColor Theme for the status bar
 
 ---@class SeparatorConfig
 ---@field arrow_solid_left string Unicode character for solid left arrow


### PR DESCRIPTION
# Description

This PR  adds a fallback mechanism if no `tab_bar` configuration is found.

closes #10